### PR TITLE
android: add frequency to scan results

### DIFF
--- a/android/src/main/java/com/lindsor/capacitor/wifi/Wifi.java
+++ b/android/src/main/java/com/lindsor/capacitor/wifi/Wifi.java
@@ -279,6 +279,7 @@ public class Wifi {
 
             wifiObject.bssid = scanResult.BSSID;
             wifiObject.level = scanResult.level;
+            wifiObject.frequency = scanResult.frequency;
             wifiObject.ssid = getScanResultSsid(scanResult);
             wifiObject.capabilities = getScanResultCapabilities(scanResult);
             wifiObject.isCurrentWifi = wifiObject.bssid.equals(currentWifiBssid);

--- a/android/src/main/java/com/lindsor/capacitor/wifi/WifiEntry.java
+++ b/android/src/main/java/com/lindsor/capacitor/wifi/WifiEntry.java
@@ -14,13 +14,14 @@ public class WifiEntry {
     public String ssid = null;
 
     public int level = -1;
-
+    public int frequency = -1;
     public boolean isCurrentWifi = false;
 
     public JSObject toCapacitorResult() {
         JSObject result = new JSObject();
         result.put("bssid", this.bssid);
         result.put("level", this.level);
+        result.put("frequency", this.frequency);
         result.put("isCurrentWifi", this.isCurrentWifi);
 
         if ("".equals(this.ssid)) {


### PR DESCRIPTION
[Frequency is returned from Android's `ScanResult`](https://developer.android.com/reference/android/net/wifi/ScanResult) so I just modified the code so that the field gets passed along to Capacitor.

Tested to work on Android 14-16, but according to the Android developer docs I expect it to work on all Android versions.