### PR TITLE
Fix BroadcastReceiver memory leak in scanForWifi

### DIFF
--- a/android/src/main/java/com/lindsor/capacitor/wifi/Wifi.java
+++ b/android/src/main/java/com/lindsor/capacitor/wifi/Wifi.java
@@ -168,12 +168,14 @@ public class Wifi {
 
                 if (!isSuccess) {
                     callback.onSuccess(getWifiScanCachedResults());
+                    context.unregisterReceiver(this);
                     return;
                 }
 
                 ArrayList<WifiEntry> wifis = getWifiScanCachedResults();
 
                 callback.onSuccess(wifis);
+                context.unregisterReceiver(this);
             }
         };
 
@@ -186,6 +188,7 @@ public class Wifi {
         }
 
         callback.onSuccess(this.getWifiScanCachedResults());
+        this.context.unregisterReceiver(wifiScanReceiver);
     }
 
     public void getCurrentWifi(GetWifiCallback callback) {


### PR DESCRIPTION
# Fix BroadcastReceiver memory leak in scanForWifi

## Summary
Fixed a critical memory leak in the Android implementation where a `BroadcastReceiver` was registered in `scanForWifi()` but never unregistered. The receiver is now properly unregistered after scan results are processed in all code paths:
- After successful scan results are received
- After unsuccessful scan results  
- When `startScan()` returns false (fallback case)

**Files changed:**
- `android/src/main/java/com/lindsor/capacitor/wifi/Wifi.java` - Added 3 lines to unregister the receiver

## Review & Testing Checklist for Human

This is a **YELLOW risk** change - the fix is straightforward but I was unable to test on an actual Android device.

- [ ] **Test wifi scanning on a physical Android device** - Verify `scanWifi()` still works correctly and returns results
- [ ] **Check for crashes** - Monitor logcat for any `IllegalArgumentException` from attempting to unregister an already-unregistered receiver
- [ ] **Verify memory leak is fixed** - Use Android Profiler to confirm the receiver is being garbage collected after scans
- [ ] **Test fallback path** - Verify the case where `wifiManager.startScan()` returns `false` (may require specific device conditions or mocking)

### Test Plan
1. Call `scanWifi()` multiple times in succession (10-20 times)
2. Use Android Profiler to monitor BroadcastReceiver instances - should not accumulate
3. Check logcat for any unregister-related exceptions
4. Verify scan results are still returned correctly

### Notes
- I was unable to run the full Android build (`npm run verify:android`) to verify compilation, only ran TypeScript build and prettier checks which passed
- The fix follows Android best practices for BroadcastReceiver lifecycle management
- This issue was identified as part of a comprehensive efficiency analysis (see EFFICIENCY_REPORT.md for other potential improvements)

**Link to Devin run:** https://app.devin.ai/sessions/7fcc006dadc142ac80efd3ab5b608a62  
**Requested by:** Marcelo Luz (marcelo.luz@lindsor.com) (@Lindsor)